### PR TITLE
fix install path for cmake files

### DIFF
--- a/CMake/InstallLibrary.cmake
+++ b/CMake/InstallLibrary.cmake
@@ -30,7 +30,9 @@ IF (WIN32)
 
   # ON LINUX : FILES MUST BE INSTALLED BY make install 
 ELSE (WIN32)
-
+  SET(INSTALL_CMAKE_DIR lib/CMake/avcd CACHE PATH
+	  "Installation directory for CMake files"
+    )
   CONFIGURE_FILE(
     ${INSTALL_LIBRARY_FILES_DIR}/FindLibrary.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/Find${LIBRARY_NAME}.cmake
@@ -38,7 +40,7 @@ ELSE (WIN32)
     )
   INSTALL( 
     FILES ${CMAKE_CURRENT_BINARY_DIR}/Find${LIBRARY_NAME}.cmake
-    DESTINATION ${CMAKE_ROOT}/Modules 
+	DESTINATION ${INSTALL_CMAKE_DIR} COMPONENT dev
     )
   CONFIGURE_FILE(
     ${INSTALL_LIBRARY_FILES_DIR}/UseLibrary.cmake.in


### PR DESCRIPTION
The installation path of FindXXX.cmake is absolute `/usr/cmake-2.8/Modules/` without respecting `${CMAKE_INSTALL_PREFIX}`. This leads to error if we want to make an installation with custom prefix and without root rights. 

This patch corrects this, by introducing a variable `INSTALL_CMAKE_DIR` with default of `lib/CMake/avcd` taken from the [cmake tutorial](http://www.cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file#The_main_FooBar.2FCMakeLists.txt_file).

regards, 
  Alexander 
