### PR TITLE
Add preprocessor conditional use of deprecated functions

### DIFF
--- a/Common/RenderWindow.cxx
+++ b/Common/RenderWindow.cxx
@@ -472,8 +472,10 @@ vtkActor* RenderWindow::SetInputData (vtkPolyData * Input)
 	{
 		Mapper=vtkPolyDataMapper::New();		
 		Mapper->SetResolveCoincidentTopologyToPolygonOffset ();
+#if VTK_MAJOR_VERSION <= 7
 		if (this->ImmediateMode)
 			Mapper->ImmediateModeRenderingOn ();
+#endif
 		this->MeshActor->SetMapper(Mapper);
 		Mapper->Delete();
 	}
@@ -819,8 +821,10 @@ vtkActor *RenderWindow::AddPolyData (vtkPolyData * Input)
 {
 
 	vtkPolyDataMapper *mapper = vtkPolyDataMapper::New ();
+#if VTK_MAJOR_VERSION <= 7
 	if (this->ImmediateMode)
 		mapper->ImmediateModeRenderingOn ();
+#endif
 	mapper->SetResolveCoincidentTopologyToPolygonOffset ();
 //	mapper->SetResolveCoincidentTopologyToShiftZBuffer();
 
@@ -910,9 +914,10 @@ RenderWindow::SetInputEdges (vtkPolyData * Edges)
 	
 		vtkPolyDataMapper *EdgesMapper = vtkPolyDataMapper::New ();
 		EdgesMapper->SetResolveCoincidentTopologyToPolygonOffset ();
+#if VTK_MAJOR_VERSION <= 7
 		if (this->ImmediateMode)
 			EdgesMapper->ImmediateModeRenderingOn ();
-
+#endif
 		this->EdgesActor = vtkActor::New ();
 		vtkIntArray *EdgesColor = vtkIntArray::New ();
 

--- a/Common/RenderWindow.h
+++ b/Common/RenderWindow.h
@@ -117,7 +117,13 @@ public:
 	void SetSize (int x, int y) {this->renWin->SetSize( x,y );};
 
 	/// sets antialiasing (the higher the more antialiased and the slower)
-	void SetAntiAliasing (int n) {this->renWin->SetAAFrames(n);};
+	void SetAntiAliasing (int n) {
+#if VTK_MAJOR_VERSION <= 7
+          this->renWin->SetAAFrames(n);
+#else
+          std::cerr <<"SetAAFrames is deprecated in VTK-8+";
+#endif
+};
 
 	/// renders the scene
 	void Render() {this->renWin->Render();};


### PR DESCRIPTION
ImmediateModeRendering and SetAAFRames are deprecated in VTK-8 (see https://www.vtk.org/Wiki/VTK/API_Changes_8_0_1_to_8_1_0)

Using conditional preprocessor directives allows to build acvd against
VTK8+ and VTK7-