### PR TITLE
Fix for compile errors about "‘fabs’ was not declared" with VTK 9.0.2

### DIFF
--- a/VolumeProcessing/vtkOOCMetaImageReader.cxx
+++ b/VolumeProcessing/vtkOOCMetaImageReader.cxx
@@ -14,6 +14,8 @@ PURPOSE.  See the above copyright notice for more information.
 =========================================================================*/
 #include "vtkOOCMetaImageReader.h"
 
+#include <cmath>
+
 #include <vtkByteSwap.h>
 #include <vtkDataArray.h>
 #include <vtkImageData.h>


### PR DESCRIPTION
With the fresh version of VTK gcc reports errors:

     ACVD/VolumeProcessing/vtkOOCMetaImageReader.cxx:219:16: error: ‘fabs’ was not declared in this scope; did you mean ‘labs’?