### PR TITLE
Use vtkSimpleCriticalSection.h instead of vtkCriticalSection.h

### DIFF
--- a/Common/vtkCurvatureMeasure.h
+++ b/Common/vtkCurvatureMeasure.h
@@ -33,7 +33,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkDataArrayCollection.h>
 #include <vtkFloatArray.h>
-#include <vtkCriticalSection.h>
+#include <vtkSimpleCriticalSection.h>
 #include "vtkSurface.h"
 #include "RenderWindow.h"
 class VTK_EXPORT vtkCurvatureMeasure : public vtkObject

--- a/DiscreteRemeshing/vtkThreadedClustering.h
+++ b/DiscreteRemeshing/vtkThreadedClustering.h
@@ -37,7 +37,7 @@ Auteur:    Sebastien VALETTE
 #include <vtkTimerLog.h>
 #include <vtkMultiThreader.h>
 #include <vtkPriorityQueue.h>
-#include <vtkCriticalSection.h>
+#include <vtkSimpleCriticalSection.h>
 
 #include "vtkUniformClustering.h"
 


### PR DESCRIPTION
In vtk 9.1 (rc1) vtkCriticalSection.h does not include vtkSimpleCriticalSection.h and uses std::mutex instead.
And vtkSimpleCriticalSection is deprecated so maybe it still needs some work.