### PR TITLE
vtkManifoldSimplification.cxx::Simplify: compilation fix

### DIFF
--- a/Common/vtkManifoldSimplification.cxx
+++ b/Common/vtkManifoldSimplification.cxx
@@ -89,7 +89,7 @@ void vtkManifoldSimplification::Simplify()
 			Vertex=Iterator.GetNextVertex();
 		}
 		
-		Neighbours1->IntersectWith(*Neighbours2);
+		Neighbours1->IntersectWith(Neighbours2);
 		
 		if (Neighbours1->GetNumberOfIds()==this->Input->GetEdgeNumberOfAdjacentFaces(Edge))
 		{


### PR DESCRIPTION
Against VTK 9 but vtkIdList::IntersectWith has [always](https://vtk.org/doc/release/7.1/html/classvtkIdList.html) required a pointer.